### PR TITLE
Fixed resolver using outdated asset names after live reloading

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -70,6 +70,7 @@ class Resolver {
    * This method is called before each compilation after changes by `webpack serv/watch`.
    */
   reset() {
+    this.data.forEach((item) => item.issuers.clear());
     this.duplicates.clear();
   }
 


### PR DESCRIPTION
When using hot reloading/live reloading (or even just recompiling while using the Webpack dev server), the `Resolver` was holding on to the old asset names. This would cause the page to fail to reload properly if the asset name had changed, for example when the asset name uses `[contenthash]`.

Alternatively, this could be fixed by changing the logic in `resolveAsset`, specifically around when an item is retrieved from the issuer.